### PR TITLE
AND-145: Ratelimit plugin

### DIFF
--- a/source/core/elysia/plugin/ratelimit.ts
+++ b/source/core/elysia/plugin/ratelimit.ts
@@ -1,0 +1,62 @@
+import { Elysia } from 'elysia';
+import type { Redis } from '#/core/store/redis';
+import { CoreError } from '#/error/coreError';
+import { HTTP_STATUS_CODE } from '#/types/enum/httpStatusCode';
+
+interface RateLimitOptions {
+    /**
+     * The Redis instance to store rate limit data
+     */
+    redis: Redis;
+    /**
+     * Maximum number of requests allowed in the window
+     */
+    limit: number;
+    /**
+     * Time window in seconds
+     */
+    window: number;
+    /**
+     * Custom error message when rate limit is exceeded
+     */
+    message?: string;
+}
+
+export const rateLimitPlugin = ({ redis, limit, window, message }: RateLimitOptions): Elysia => new Elysia({
+    name: 'rateLimitPlugin'
+})
+    .onRequest(async ({ request }) => {
+        const ip = request.headers.get('x-forwarded-for')
+            || request.headers.get('x-real-ip')
+            || '127.0.0.1';
+
+        const key = `ratelimit:${ip}`;
+
+        // Get current count for this IP
+        const current = await redis.client.get(key);
+        const count = current ? parseInt(current) : 0;
+
+        if (count >= limit)
+            throw new CoreError({
+                key: 'core.error.rate_limit_exceeded',
+                message: message || 'Rate limit exceeded',
+                httpStatusCode: HTTP_STATUS_CODE.TOO_MANY_REQUESTS,
+                cause: {
+                    limit,
+                    window,
+                    remaining: 0,
+                    reset: await redis.client.ttl(key)
+                }
+            });
+
+
+        if (count === 0)
+            await redis.client.setex(key, window, '1');
+        else
+            await redis.client.incr(key);
+
+
+        request.headers.set('X-RateLimit-Limit', limit.toString());
+        request.headers.set('X-RateLimit-Remaining', (limit - count - 1).toString());
+        request.headers.set('X-RateLimit-Reset', (await redis.client.ttl(key)).toString());
+    });

--- a/source/error/key/elysiaKeyError.ts
+++ b/source/error/key/elysiaKeyError.ts
@@ -4,5 +4,6 @@
 export const ELYSIA_KEY_ERROR = {
     WRONG_EMAIL_OR_PASSWORD: 'core.error.elysia.wrong_email_or_password',
     WRONG_MFA: 'core.error.elysia.wrong_mfa_token',
-    UNAUTHORIZED: 'core.error.elysia.unauthorized'
+    UNAUTHORIZED: 'core.error.elysia.unauthorized',
+    RATE_LIMIT_EXCEEDED: 'core.error.rate_limit_exceeded'
 } as const;

--- a/test/core/elysia/plugin/ratelimit.spec.ts
+++ b/test/core/elysia/plugin/ratelimit.spec.ts
@@ -1,0 +1,86 @@
+import { rateLimitPlugin } from '#/core/elysia/plugin/ratelimit';
+import { Redis } from '#/core/store/redis';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+
+describe('Rate Limit Plugin', () => {
+    const redis = new Redis({
+        host: 'localhost',
+        port: 6379
+    });
+
+    afterEach(async () => {
+        const keys = await redis.client.keys('ratelimit:*');
+        if (keys.length > 0)
+            await redis.client.del(...keys);
+    });
+
+    const app = new Elysia()
+        .use(rateLimitPlugin({
+            redis,
+            limit: 5, // 5 requests
+            window: 60, // per minute
+            message: 'Trop de requêtes, veuillez réessayer plus tard'
+        }))
+        .get('/', () => 'Hello World!');
+
+    test('should allow requests within rate limit', async () => {
+        const ip = '127.0.0.12';
+
+        // Send 5 requests (within limit)
+        for (let i = 0; i < 5; i++) {
+            const response = await app.handle(
+                new Request('http://localhost/', {
+                    headers: { 'x-forwarded-for': ip }
+                })
+            );
+
+            expect(response.status).toEqual(200);
+            const text = await response.text();
+            expect(text).toEqual('Hello World!');
+
+            // Check rate limit headers
+            const remaining = response.headers.get('X-RateLimit-Remaining');
+            const limit = response.headers.get('X-RateLimit-Limit');
+
+            expect(remaining).toBeDefined();
+            expect(parseInt(remaining || '0')).toEqual(4 - i);
+            expect(limit).toEqual('5');
+        }
+    });
+
+    test('should block requests exceeding rate limit', async () => {
+        const ip = '127.0.0.12';
+
+        for (let i = 0; i < 5; i++)
+            await app.handle(
+                new Request('http://localhost/', {
+                    headers: { 'x-forwarded-for': ip }
+                })
+            );
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        const blockedResponse = await app.handle(
+            new Request('http://localhost/', {
+                headers: { 'x-forwarded-for': ip }
+            })
+        );
+
+        expect(blockedResponse.status).toBe(429);
+        const errorText = await blockedResponse.text();
+        expect(errorText).toEqual('Trop de requêtes, veuillez réessayer plus tard');
+    });
+
+    test('should reset rate limit after window period', async () => {
+        const ip = '1.2.3.4';
+
+        const response = await app.handle(new Request('http://localhost/', {
+            headers: { 'x-forwarded-for': ip }
+        }));
+
+        expect(response.status).toEqual(200);
+        const resetTime = parseInt(response.headers.get('X-RateLimit-Reset') || '0');
+        expect(resetTime).toBeLessThanOrEqual(60);
+    });
+});

--- a/test/core/elysia/plugin/ratelimit.spec.ts
+++ b/test/core/elysia/plugin/ratelimit.spec.ts
@@ -1,7 +1,8 @@
+import { Elysia } from 'elysia';
+
 import { rateLimitPlugin } from '#/core/elysia/plugin/ratelimit';
 import { Redis } from '#/core/store/redis';
 import { afterEach, describe, expect, test } from 'bun:test';
-import { Elysia } from 'elysia';
 
 describe('Rate Limit Plugin', () => {
     const redis = new Redis({


### PR DESCRIPTION
📌 Objectif du ticket

Développer un plugin Elysia permettant de limiter le nombre de requêtes par IP afin d'éviter les abus et de mieux gérer le trafic.
🛠️ Détails

    Implémenter une logique de rate limiting basée sur l'adresse IP.

    Utiliser le hook onRequest pour intercepter et contrôler le flux des requêtes.

    Permettre la configuration des seuils (exemple : nombre de requêtes max par minute).