### PR TITLE
AND-301 :  fix crud.usecase.ts find<T>(...) delete throwIfNoResult

### DIFF
--- a/source/domain/usecase/crud.usecase.ts
+++ b/source/domain/usecase/crud.usecase.ts
@@ -61,7 +61,7 @@ function find<T>(
         databaseName,
         primaryKey
     );
-    return crudRepository.find(search, {}, { ...pagination, throwIfNoResult: true }) as Promise<Partial<T>[] | void>;
+    return crudRepository.find(search, {}, { ...pagination }) as Promise<Partial<T>[] | void>;
 }
 
 /**


### PR DESCRIPTION
## Refactoring
- Removed unnecessary `throwIfNoResult` option from the `crudRepository.find` call.